### PR TITLE
普通の配列でもキーを列挙出来るように変更

### DIFF
--- a/CNako2Test/TestNodeForeach.cs
+++ b/CNako2Test/TestNodeForeach.cs
@@ -69,7 +69,7 @@ namespace NakoPluginTest
 				"A[`b`]=`bbb`\n"+
 				"A[`c`]=`ccc`\n"+
 				"(Aの配列ハッシュキー列挙)で反復\n"+
-				"  「***:{対象}」を継続表示\n"+
+				"  「***{回数}:{対象}」を継続表示\n"+
 				""
 			);
 			runner.Run(codes);
@@ -80,11 +80,11 @@ namespace NakoPluginTest
 				"A[1]=`bbb`\n"+
 				"A[2]=`ccc`\n"+
 				"(Aの配列ハッシュキー列挙)で反復\n"+
-				"  「***:{対象}」を継続表示\n"+
+				"  「***{回数}:{対象}」を継続表示\n"+
 				""
 			);
 			runner.Run(codes);
-			Assert.AreEqual(runner.PrintLog, "***1:a***2:b***3:c");
+			Assert.AreEqual(runner.PrintLog, "***1:1***2:2***3:10");
 
 		}
 		[Test]

--- a/NakoPlugin/NakoVarArray.cs
+++ b/NakoPlugin/NakoVarArray.cs
@@ -49,13 +49,17 @@ namespace NakoPlugin
         /// <returns></returns>
         public string[] GetKeys()
         {
-            string[] r = new string[list.Count];
+            //string[] r = new string[list.Count];
+			System.Collections.Generic.List<string> r = new System.Collections.Generic.List<string>();
             for (int i = 0; i < list.Count; i++)
             {
                 NakoVariable v = list[i];
-                r[i] = v.key;
+				if (v != null) {
+					//r [i] = v.key;
+					r.Add((v.key==null)? i.ToString() : v.key);
+				}
             }
-            return r;
+			return r.ToArray();
         }
 
         /// <summary>
@@ -85,7 +89,7 @@ namespace NakoPlugin
         public object GetValue(int index)
         {
             NakoVariable v = GetVar(index);
-            if (v == null) return null;
+			if (v == null) return null; 
             return v.Body;
         }
         /// <summary>


### PR DESCRIPTION
配列で例えばA[0]、A[1]、A[10]だけ値が登録されている場合に、配列のキーを
「配列ハッシュキー列挙」で取り出したいと思ったので、テストと実装を追加しました。