### PR TITLE
他のファイルの修正をしないテストを追加

### DIFF
--- a/CNako2Test/TestBaseSystem.cs
+++ b/CNako2Test/TestBaseSystem.cs
@@ -141,6 +141,12 @@ namespace NakoPluginTest
                 "Aを「0.1」で切り下げして継続表示\n" +
                 ""));
             Assert.AreEqual("10", runner.PrintLog);
+            runner.Run (com.WriteIL(
+                "A=10.000001\n" +
+                "B=(Aを「0.000001」で切り下げ)+0.000001\n" +
+                "Bを継続表示\n" +
+                ""));
+            Assert.AreEqual("10.000002", runner.PrintLog);
 
 //            runner.Run (com.WriteIL(
 //                "0.162をAに代入\n" +

--- a/CNako2Test/TestNodeCallFunction.cs
+++ b/CNako2Test/TestNodeCallFunction.cs
@@ -234,5 +234,19 @@ namespace NakoPluginTest
 			runner.Run(codes);
 			Assert.AreEqual(runner.PrintLog, "ふが");
 		}
+        [Test]
+        public void TestCallUserFuncAndCheckGlobalVar()
+        {
+            codes = ns.WriteIL(
+                "●ほげ\n" +
+                "  A＝「ふが」\n" +
+                "  Aで戻る\n" +
+                "A=`hoge`\n" +
+                "B = ほげ\n" +
+                "PRINT A\n" +
+                "\n");
+            runner.Run(codes);
+            Assert.AreEqual("hoge",runner.PrintLog);
+        }
     }
 }

--- a/NakoPluginTest/TestNakoADO.cs
+++ b/NakoPluginTest/TestNakoADO.cs
@@ -74,12 +74,13 @@ namespace NakoPluginTest
         [Test]
         public void TestSelectDate()
         {
+            //TODO:64bit linuxではエラーが出ることがある。monoのパッチを当てると良いらしいが・・・
             runner.Run(com.WriteIL(
                 "A="+this.connection+"でADO開く\n" +
                 "B=Aに『select cast('2014-01-01' as date)』をSQL実行\n" +
                 "(AのDB次移動)==1の間\n" +
                 "  C=Aへ『date』のDBフィールド取得\n" +
-                 "  Cを表示\n" +
+                "  Cを表示\n" +
                 "AをDB閉じる"));
             Assert.AreEqual("2014/01/01 0:00:00", runner.PrintLog );
         }

--- a/NakoPluginTest/TestNakoPluginCtrl.cs
+++ b/NakoPluginTest/TestNakoPluginCtrl.cs
@@ -39,25 +39,37 @@ namespace NakoPluginTest
         [Test][STAThreadAttribute]
         public void TestClipboad()
         {
+            if(NWEnviroment.isWindows()){
             runner.Run(com.WriteIL(
                 "「abc」をコピー。\n" +
                 "クリップボードを表示。"));
             Assert.AreEqual("abc", runner.PrintLog);
+            }else{
+                Assert.Pass("Windows環境でないのでスキップ");
+            }
         }
         [Test][STAThreadAttribute]
         public void TestClipboad2()
         {
+            if(NWEnviroment.isWindows()){
             runner.Run(com.WriteIL(
                 "10をコピー。\n" +
                 "クリップボードを表示。"));
             Assert.AreEqual("10", runner.PrintLog);
+            }else{
+                Assert.Pass("Windows環境でないのでスキップ");
+            }
         }
         [Test][STAThreadAttribute]
         public void TestEnumWindows()
         {
+            if(NWEnviroment.isWindows()){
             runner.Run(com.WriteIL(
                 "窓列挙して表示。\n"));
             Assert.AreNotEqual("", runner.PrintLog);
+            }else{
+                Assert.Pass("Windows環境でないのでスキップ");
+            }
         }
         [Test]
         public void TestGuid()//TODO:Success test

--- a/NakoPluginTest/TestNakoPluginSystem.cs
+++ b/NakoPluginTest/TestNakoPluginSystem.cs
@@ -106,7 +106,6 @@ namespace NakoPluginTest
             Assert.AreEqual("1", runner.PrintLog );
         }
 
-		[Test]
 		public void TestQuit()
 		{
 			runner.Run(com.WriteIL(


### PR DESCRIPTION
切り下げ命令のテスト
関数呼出時のグローバル変数汚染に関するテスト
クリップボード、ウィンドウ関連のテストをWindows以外の場合にスキップ
など、プラグイン等他のファイルの修正無しで加えたテストをここにまとめています。