### PR TITLE
タグ切り出しの変更

### DIFF
--- a/NakoPluginTag/NakoPluginTag.cs
+++ b/NakoPluginTag/NakoPluginTag.cs
@@ -56,13 +56,19 @@ namespace NakoPluginTag
         	string s = info.StackPopAsString();
         	string a = info.StackPopAsString();
         	HtmlDocument doc = new HtmlDocument();
+            doc.OptionFixNestedTags = true;
+            doc.OptionOutputAsXml = true;
         	doc.LoadHtml(s);
+            string html = doc.DocumentNode.OuterHtml;
         	HtmlNodeCollection nodes = doc.DocumentNode.SelectNodes(String.Format(@"//{0}",a));
         	NakoVarArray res = info.CreateArray();
         	if(nodes!=null){
             	for(int i=0;i<nodes.Count;i++){
-            	    HtmlNode node = nodes[i];
-            	    res.SetValue(i,node.InnerHtml);
+                    HtmlNode node = nodes[i];
+                    if(html.Contains(node.OuterHtml)){
+                        res.SetValue(i,node.InnerHtml);
+                        html = html.Remove(html.IndexOf(node.OuterHtml), node.OuterHtml.Length);
+                    }
             	}
         	}
             return res;

--- a/NakoPluginTag/NakoPluginTag.csproj
+++ b/NakoPluginTag/NakoPluginTag.csproj
@@ -9,7 +9,7 @@
     <AssemblyName>NakoPluginTag</AssemblyName>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <ProductVersion>10.0.0</ProductVersion>
+    <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Platform)' == 'x86' ">
@@ -42,9 +42,7 @@
       <HintPath>HtmlAgilityPack.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Core">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
+    <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/NakoPluginTest/TestNakoPluginTag.cs
+++ b/NakoPluginTest/TestNakoPluginTag.cs
@@ -46,6 +46,27 @@ namespace NakoPluginTest
                 "TAG=Sから「で」のタグ切り出し\n" +
                 "TAG[0]を表示。"));
             Assert.AreEqual("で",runner.PrintLog);
+            runner.Run(com.WriteIL(
+                "S=「<な>な</な><で>で</で><し>し</し><こ>こ</こ>」\n" +
+                "TAG=Sから「で」のタグ切り出し\n" +
+                "TAGで反復\n" +
+                "  (対象 == 「で」)を表示。"));
+            Assert.AreEqual("True",runner.PrintLog);
+            runner.Run(com.WriteIL(
+                "S=「<td><p align='right'></p></td>」\n" +
+                "TAG=Sから「td」のタグ切り出し\n" +
+                "TAG[0]を表示。"));
+            Assert.AreEqual("<p align='right' />",runner.PrintLog);
+        }
+
+        [Test]
+        public void TestNest()
+        {
+            runner.Run(com.WriteIL( 
+                "S=「<html><body><div>なで<div>しこ</div></div></body></html>」\n" +
+                "TAG=Sから「div」のタグ切り出し\n" +
+                "(TAGの要素数)を表示。"));
+            Assert.AreEqual("1",runner.PrintLog);
         }
 
         [Test]


### PR DESCRIPTION
タグ切り出しについて
・ネストしたタグは一番外側を切り出すように変更
・壊れたタグも切り出せるよう変更
・テスト追加
しました。
変更前もそうですが、空タグが勝手に変化してしまうので、さらに修正が必要だと思いますが、取りあえず使える状態なのでアップしてみました。
例：<p></p>　→　<p />