### PR TITLE
正規表現マッチの時にマッチしない場合に空文字を返すように変更しました

### DIFF
--- a/NakoPluginRegex/NakoPluginRegex.cs
+++ b/NakoPluginRegex/NakoPluginRegex.cs
@@ -59,7 +59,7 @@ namespace NakoPluginRegex
                 info.SetVariableValue("抽出文字列", groups);
         	    return m.Value;
         	}
-            return null;
+            return "";
         }
         public Object _matchAll(INakoFuncCallInfo info)
         {

--- a/NakoPluginRegex/NakoPluginRegex.csproj
+++ b/NakoPluginRegex/NakoPluginRegex.csproj
@@ -9,7 +9,7 @@
     <AssemblyName>NakoPluginRegex</AssemblyName>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <ProductVersion>10.0.0</ProductVersion>
+    <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Platform)' == 'x86' ">
@@ -39,9 +39,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
+    <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="NakoPluginRegex.cs" />

--- a/NakoPluginTest/TestNakoPluginRegex.cs
+++ b/NakoPluginTest/TestNakoPluginRegex.cs
@@ -41,6 +41,14 @@ namespace NakoPluginTest
         }
 
         [Test]
+        public void TestNotMatch()
+        {
+            runner.Run(com.WriteIL(
+                "M=「なでしこ」の「^hoge$」を正規表現マッチ。(M == 「」)を表示"));
+            Assert.AreEqual("True", runner.PrintLog);
+        }
+
+        [Test]
         public void TestMatchAll()
         {
             runner.Run(com.WriteIL(


### PR DESCRIPTION
正規表現マッチでマッチしない場合にnullを返していたので空文字を返すように変更しました。
正規表現マッチしない場合のテストも追加しました。
なでしこでは現在nullを扱えないので、null相当の何かを用意した方が良いのか、今回のように空文字で良いのかは判断付きませんでした。