### PR TITLE
関数内の変数をローカルに変更

### DIFF
--- a/Libnako/JPNCompiler/Parser/NakoParser.cs
+++ b/Libnako/JPNCompiler/Parser/NakoParser.cs
@@ -747,12 +747,12 @@ namespace Libnako.JPNCompiler.Parser
             parentNode = funcNode.funcBody = new NakoNode();
             funcNode.RegistArgsToLocalVar();
             localVar = funcNode.localVar;
-			current_scope = NakoVariableScope.Local;
+            current_scope = NakoVariableScope.Local;
             if (!_scope())
             {
                 throw new NakoParserException("関数定義中のエラー。", t);
             }
-			current_scope = NakoVariableScope.Global;
+            current_scope = NakoVariableScope.Global;
             PopFrame();
             // グローバル変数に登録
             NakoVariable v = new NakoVariable();
@@ -909,7 +909,7 @@ namespace Libnako.JPNCompiler.Parser
             if (!Accept(NakoTokenType.WORD)) return false;
             // 設定用変数の取得
             NakoNodeVariable n = new NakoNodeVariable();
-			n.scope = current_scope;
+            n.scope = current_scope;
             n.type = NakoNodeType.ST_VARIABLE;
             n.Token = tok.CurrentToken;
             // 変数アクセス

--- a/Libnako/JPNCompiler/Parser/NakoParserBase.cs
+++ b/Libnako/JPNCompiler/Parser/NakoParserBase.cs
@@ -73,7 +73,7 @@ namespace Libnako.JPNCompiler.Parser
             set { _globalVar = value; }
         }
         private NakoVariableManager _globalVar = null;
-		public NakoVariableScope current_scope = NakoVariableScope.Global;
+        public NakoVariableScope current_scope = NakoVariableScope.Global;
         /// <summary>
         /// コンストラクタ
         /// </summary>

--- a/Libnako/JPNCompiler/Parser/NakoParserBase.cs
+++ b/Libnako/JPNCompiler/Parser/NakoParserBase.cs
@@ -73,7 +73,7 @@ namespace Libnako.JPNCompiler.Parser
             set { _globalVar = value; }
         }
         private NakoVariableManager _globalVar = null;
-
+		public NakoVariableScope current_scope = NakoVariableScope.Global;
         /// <summary>
         /// コンストラクタ
         /// </summary>


### PR DESCRIPTION
関数内の変数はローカルスコープが良いかなと思いましたので、
関数内のブロックはローカルスコープで変数を登録するよう変更しました。
CNako2Test/TestNodeCallFunction.cs
のTestCallUserFuncAndCheckGlobalVar
が、この変更で通るようになります。
この実装で良いかどうかは自信がありませんが。